### PR TITLE
Allow new-config to be called after slackpkg upgrade

### DIFF
--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -345,6 +345,7 @@ use slackpkg.\n"
 		CHECKMD5=off
 	elif ! [ -f ${ROOT}/${WORKDIR}/CHECKSUMS.md5 ] && \
 		[ "$CMD" != "update" ] && \
+		[ "$CMD" != "new-config" ] && \
 		[ "$CHECKMD5" = "on" ]; then
 		echo -e "\n\
 No CHECKSUMS.md5 found!  Please disable md5sums checking\n\


### PR DESCRIPTION
Includes new-config in the list of commands that can be called with the slackpkg's var directory empty.

Fixes: #7 