### PR TITLE
New exit status for different situations

### DIFF
--- a/doinst.sh
+++ b/doinst.sh
@@ -39,5 +39,6 @@ copy_mirror_file
 config etc/slackpkg/mirrors.new
 config etc/slackpkg/slackpkg.conf.new
 config etc/slackpkg/blacklist.new
+rm -f var/lib/slackpkg/ChangeLog.txt
 rm -f var/lib/slackpkg/pkglist
 rm -f var/lib/slackpkg/CHECKSUMS.md5*

--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -7,7 +7,7 @@
 # Clean-up tmp and lock files
 #
 function cleanup() {
-	local retval=${PENDING_UPDATES:-0}
+	local retval=${EXIT_CODE:-0}
 	[ "$SPINNING" = "off" ] || tput cnorm
 	if [ -e $TMPDIR/error.log ]; then
 		retval=1

--- a/files/slackpkg
+++ b/files/slackpkg
@@ -332,7 +332,7 @@ case "$CMD" in
 			echo "Slackpkg: No updated packages since last check."
 		else
 			echo "Slackpkg: Updated packages are available since last check." >&2
-			PENDING_UPDATES=1
+			EXIT_CODE=100
 		fi
 		;;
 	show-changelog)
@@ -368,6 +368,7 @@ case "$CMD" in
 			echo -e "No packages match the pattern for install. Try:"
 			echo -e "\n\t$0 reinstall|upgrade $2\n"
 			POSTINST=off
+			EXIT_CODE=20
 		fi
 	;;
 	reinstall)
@@ -379,6 +380,7 @@ case "$CMD" in
 			echo -e "No packages match the pattern for reinstall. Try:"
 			echo -e "\n\t$0 install|upgrade $2\n"
 			POSTINST=off
+			EXIT_CODE=20
 		fi
 	;;
 	upgrade)
@@ -391,6 +393,7 @@ case "$CMD" in
 			echo -e "No packages match the pattern for upgrade. Try:"
 			echo -e "\n\t$0 install|reinstall $2\n"
 			POSTINST=off
+			EXIT_CODE=20
 		fi
 	;;
 	download)
@@ -404,12 +407,14 @@ case "$CMD" in
 		else
 			echo -e "No packages match the pattern for download."
 			POSTINST=off
+			EXIT_CODE=20
 		fi
 	;;
 	remove)
 		makelist $INPUTLIST
 		if [ "$LIST" = "" ]; then
 			echo -e "The file(s) $INPUTLIST can't be removed - package not installed.\n"
+			EXIT_CODE=20
 			cleanup
 		fi
 		showlist "$LIST" $CMD
@@ -423,6 +428,7 @@ case "$CMD" in
 		else
 			echo -e "No packages match the pattern for clean-system\n"
 			POSTINST=off
+			EXIT_CODE=20
 		fi
 	;;
 	upgrade-all)
@@ -432,6 +438,7 @@ case "$CMD" in
 			echo -e "No packages match the pattern for upgrade. Try:"
 			echo -e "\n\t$0 install|reinstall $2\n"
 			POSTINST=off
+			EXIT_CODE=20
 		else
 			showlist "$LIST" upgrade
 			if [ "$DOWNLOAD_ALL" = "on" ]; then
@@ -447,8 +454,9 @@ case "$CMD" in
 			if [ "$FOUND" != "" ]; then 
 				getpkg $FOUND upgradepkg Upgrading
 				echo -e "slackpkg was upgraded - you will need start the upgrade process again...\n"
+				EXIT_CODE=50
 				cleanup
-				exit 0
+				exit ${EXIT_CODE}
 			fi
 			for i in pkgtools aaa_glibc-solibs glibc-solibs aaa_libraries aaa_elflibs readline sed; do
 				FOUND=""
@@ -466,6 +474,7 @@ case "$CMD" in
 			echo -e "No packages match the pattern for install. Try:"
 			echo -e "\n\t$0 upgrade|reinstall $2\n"
 			POSTINST=off
+			EXIT_CODE=20
 		else
 			showlist "$LIST" install
 			install_pkg

--- a/files/slackpkg.8
+++ b/files/slackpkg.8
@@ -1,4 +1,4 @@
-.TH SLACKPKG 8 "March 12, 2021" slackpkg-15.0.1 ""
+.TH SLACKPKG 8 "Oct 8, 2021" slackpkg-15.0.8 ""
 .SH NAME
 .B slackpkg
 \- Automated tool for managing Slackware Linux packages
@@ -305,6 +305,20 @@ If you happen to be looking for a filename-with-space, you are safe to use the
 left-most part up to the space (in that the right-most part after the space
 will be ignored anyway (at best) or yield noise (at worst)).
 
+.SH EXIT STATUS
+.P
+.IP "\fB0\fP" 5
+Successful slackpkg execution.
+.IP "\fB1\fP" 5
+Something wrong happened.
+.IP "\fB20\fP" 5
+No package found to be downloaded, installed, reinstalled, upgraded or
+removed.
+.IP "\fB50\fP" 5
+Slackpkg itself was upgraded and you need to re-run it.
+.IP "\fB100\fP" 5
+There are pending updates.
+
 .SH FILES
 .TP 5
 .B /etc/slackpkg/mirrors
@@ -333,11 +347,3 @@ ChangeLog.txt, list of files, etcetera...
 .BR explodepkg (8),
 .BR makepkg (8),
 .BR pkgtool (8).
-
-.SH AUTHORS
-.TP 5
-Piter PUNK aka Roberto F Batista
-<piterpk AT terra DOT com DOT br>
-.TP 5
-Evaldo Gardenali aka UdontKnow
-<evaldo AT fasternet DOT com DOT br>


### PR DESCRIPTION
To make easier to do an unattended Slackpkg update/upgrade process,
this commit provides different exit codes to many situations:

- `0`    Successful Slackpkg execution.
- `1`    Something wrong happened.
- `20`   No package found to be downloaded, installed, reinstalled, upgraded or removed.
- `50`   Slackpkg itself was upgraded and you need to re-run it.
- `100`  There are pending updates.

Code and the main man page are updated accordingly.

In addition, this commit also:

- removes the `ChangeLog.txt` in `doinst.sh`, so the needed `slackpkg update` after Slackpkg upgrade won't says it's all OK and don't need to redo the package lists
- removes `AUTHORS` from man page. Nowadays there are code from many people in Slackpkg and shows a bit unfair to have only my and Evaldo's name listed there.