### PR TITLE
Always rebuilds package lists if missing

### DIFF
--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -243,11 +243,9 @@ ONE mirror in ${CONF}/mirrors and run:\n\n\
 You can see more information about slackpkg functions in slackpkg manpage."
 			cleanup
 		elif [ "$CMD" != "new-config" ] && [ "$CMD" != "help" ]; then
-			echo -e "\
-\nThe package list is missing.\n\
-Before you install|upgrade|reinstall anything you need to run:\n\n\
-\t# slackpkg update\n"
-			cleanup
+			updatefilelists
+			mkregex_blacklist
+			UPDATED=1
 		fi
 	fi                                                      
 
@@ -1083,6 +1081,7 @@ Please check your mirror and try again."
 
 function updatefilelists()
 {
+	echo "Updating the package lists..."
 	if checkchangelog ; then
 		echo -e "\
 \n\t\tNo changes in ChangeLog.txt between your last update and now.\n\

--- a/files/slackpkg
+++ b/files/slackpkg
@@ -328,7 +328,7 @@ case "$CMD" in
 	check-updates)
 		# output to stdout if no change, or stderr if changes. Will cause
 		# cron jobs to notify system admin
-		if checkchangelog 1>/dev/null 2>/dev/null ; then
+		if checkchangelog 1>/dev/null 2>/dev/null && [ "$UPDATED" != "1" ] ; then
 			echo "Slackpkg: No updated packages since last check."
 		else
 			echo "Slackpkg: Updated packages are available since last check." >&2
@@ -356,7 +356,6 @@ case "$CMD" in
 				cleanup
 			fi
 		fi
-		echo "Updating the package lists..."
 		updatefilelists
 	;;
 	install)


### PR DESCRIPTION
This PR changes the behaviour of Slackpkg if the package lists are missing.

Before this PR, the user was asked to run `slackpkg update` to download and rebuilt the lists.

With this PR applied, the package lists will be automatically downloaded and rebuilt when missing.

Keep in mind this does not eliminate the `slackpkg update` need if there is a package list file present. In this case, the user still needs to run it to update the package lists with the new contents.

Fixes: #16 