### PR TITLE
File to flag if the system needs restart

### DIFF
--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -1320,20 +1320,24 @@ for slackpkg to work properly.
 
 # Checks if a critical package were upgraded by Slackpkg.
 # The /var/run/needs_restarting file contains the list of upgraded
-# packages and will be removed at boot.
+# packages.
 #
+# The file only is created if /var/run filesystem type is tmpfs so
+# the reboot will clean it
 function needs_restarting() {
-	find $ROOT/var/log/packages/ -cnewer $TMPDIR/timestamp -type f \( \
-		-name "kernel-generic-[0-9]*" -o \
-		-name "kernel-huge-[0-9]*" -o \
-		-name "openssl-solibs-[0-9]*" -o \
-		-name "openssl-[0-9]*" -o \
-		-name "glibc-[0-9]*" -o \
-		-name "aaa_glibc-solibs-[0-9]*" -o \
-		-name "eudev-[0-9]*" -o \
-		-name "elogind-[0-9]*" -o \
-		-name "dbus-[0-9]*" \) | \
-	awk -F/ '{ print $NF }' >> $ROOT/var/run/needs_restarting
+	if [ "$(stat -f -c %T /var/run/)" = "tmpfs" ]; then
+		find $ROOT/var/log/packages/ -cnewer $TMPDIR/timestamp -type f \( \
+			-name "kernel-generic-[0-9]*" -o \
+			-name "kernel-huge-[0-9]*" -o \
+			-name "openssl-solibs-[0-9]*" -o \
+			-name "openssl-[0-9]*" -o \
+			-name "glibc-[0-9]*" -o \
+			-name "aaa_glibc-solibs-[0-9]*" -o \
+			-name "eudev-[0-9]*" -o \
+			-name "elogind-[0-9]*" -o \
+			-name "dbus-[0-9]*" \) | \
+		awk -F/ '{ print $NF }' >> $ROOT/var/run/needs_restarting
+	fi
 }
 
 function remove_pkg() {

--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -1318,6 +1318,24 @@ for slackpkg to work properly.
 	fi
 }	
 
+# Checks if a critical package were upgraded by Slackpkg.
+# The /var/run/needs_restarting file contains the list of upgraded
+# packages and will be removed at boot.
+#
+function needs_restarting() {
+	find $ROOT/var/log/packages/ -cnewer $TMPDIR/timestamp -type f \( \
+		-name "kernel-generic-[0-9]*" -o \
+		-name "kernel-huge-[0-9]*" -o \
+		-name "openssl-solibs-[0-9]*" -o \
+		-name "openssl-[0-9]*" -o \
+		-name "glibc-[0-9]*" -o \
+		-name "aaa_glibc-solibs-[0-9]*" -o \
+		-name "eudev-[0-9]*" -o \
+		-name "elogind-[0-9]*" -o \
+		-name "dbus-[0-9]*" \) | \
+	awk -F/ '{ print $NF }' >> $ROOT/var/run/needs_restarting
+}
+
 function remove_pkg() {
 	local i
 
@@ -1342,6 +1360,7 @@ function upgrade_pkg() {
 	for i in $SHOWLIST; do
 		getpkg $i upgradepkg Upgrading
 	done
+	needs_restarting
 }
 
 function install_pkg() {


### PR DESCRIPTION
Creates `/var/run/needs_restarting` file if any critical package got upgraded. As the `/var/run/` is ephemeral and renewed each boot, the file disappears after reboot.

The packages that flags the restart need are:

- `kernel-generic`, `kernel-huge`: as a new kernel needs a restart to be running.
- `glibc`, `glibc-solibs`: Restart is the only way to be sure that all  running binaries are using the new Glibc.
- `eudev`, `elogind`, `dbus`: those provides some very basic system services.
- `openssl`, `openssl-solibs`: security bugs on those libs are dangerous, the reboot makes sure that all running binaries are using the newer version.

Fixes #20 