### PR TITLE
Unattended usage improvements

### DIFF
--- a/files/post-functions.conf-sample
+++ b/files/post-functions.conf-sample
@@ -1,4 +1,4 @@
-# You can list here the .new files and the default action 
+# You can list here the .new files and the default action
 # to do for each file. The list format is:
 # 
 # /full/path/of/dot/new/file.new:action
@@ -9,6 +9,11 @@
 # R to Remove the new file
 # K to Keep the current and the .new files
 #
+# Using "default" as file name, you'll set the action for
+# the .new files in batch mode. The action for each file
+# takes precedence over the "default" one.
+#
 # E.g:
 #/etc/slackpkg/mirrors.new:K
 #/etc/ntp.conf.new:R
+#default:O

--- a/files/post-functions.sh
+++ b/files/post-functions.sh
@@ -152,6 +152,7 @@ looknew() {
 		-name "*.new" \
 		${ONLY_NEW_DOTNEW} \
 		-not -name "rc.inet1.conf.new" \
+		-not -name "rc.wireless.conf.new" \
 		-not -name "group.new" \
 		-not -name "passwd.new" \
 		-not -name "shadow.new" \
@@ -248,6 +249,9 @@ EOF
 		answer
 		if [ "${BATCH}" = "on" ] && [ -n "${NEWCONFIG}" ]; then
 			ANSWER=P
+
+			# This allows to have a default behaviour for all .new files in batch mode.
+			DEF_AUTOANSWER="$(sed -ne 's#^default:\([ORK]\)#\1#p' $NEWCONFIG 2>/dev/null)"
 		fi
 		case $ANSWER in
 			K|k)
@@ -277,7 +281,7 @@ EOF
 							echo $ANSWER
 						else
 							if [ "${BATCH}" = "on" ]; then
-								ANSWER=K
+								ANSWER=${DEF_AUTOANSWER:-K}
 								echo $ANSWER
 							else
 								read ANSWER
@@ -340,7 +344,10 @@ Your kernel image was updated, and lilo does not appear to be used on
 your system.  You may need to adjust your boot manager (like GRUB) to 
 boot the appropriate kernel (after generating an initrd if required)."
 		fi
-		echo -e "Press the \"Enter\" key to continue...\n "
-		read _junk
+
+		if [ "${BATCH}" != "on" ]; then
+			echo -e "Press the \"Enter\" key to continue...\n "
+			read _junk
+		fi
 	fi
 }


### PR DESCRIPTION
- When in batch mode, don't wait for `enter` after kernel upgrade, so Slackpkg will not wait forever.
- Also in batch mode, allow to set a default action about what to do with `.new` config files. The syntex is documented in `post-functions.conf-sample`

Fixes #18 
Fixes #19 