### PR TITLE
Allow file-search to find full file paths

### DIFF
--- a/files/slackpkg
+++ b/files/slackpkg
@@ -487,7 +487,7 @@ case "$CMD" in
 		echo -e ""
 	;;
 	file-search)
-		PATTERN=$(echo $ARG | sed -e 's/\+/\\\+/g' -e 's/\./\\\./g' -e 's/ /\|/g')
+		PATTERN=$(echo $ARG | sed -e 's/^\///g' -e 's/\+/\\\+/g' -e 's/\./\\\./g' -e 's/ /\|/g')
 		makelist $PATTERN
 
 		if [ "$LIST" = "" ]; then


### PR DESCRIPTION
Removing any initial `/` from the pattern argument for `file-search` would allow it to show results for full file paths. This would make it more convenient to use tab completion when searching.