### PR TITLE
Adds SLACKCFVERSION explicitly at slackpkg.conf

### DIFF
--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -160,7 +160,9 @@ function system_setup() {
 	# ${CONF}/blacklist.
 	[ "$CMD" != update ] && mkregex_blacklist
 
+    if [ -z "${SLACKCFVERSION}" ]; then
 	SLACKCFVERSION=$(grep "# v[0-9.]\+" $CONF/slackpkg.conf | cut -f2 -dv)
+    fi
 	CHECKSUMSFILE=${WORKDIR}/CHECKSUMS.md5
 	KERNELMD5=$(md5sum /boot/vmlinuz 2>/dev/null)
 	DIALOG_MAXARGS=${DIALOG_MAXARGS:-19500}

--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -161,7 +161,7 @@ function system_setup() {
 	[ "$CMD" != update ] && mkregex_blacklist
 
 	if [ -z "${SLACKCFVERSION}" ]; then
-	SLACKCFVERSION=$(grep "# v[0-9.]\+" $CONF/slackpkg.conf | cut -f2 -dv)
+		SLACKCFVERSION=$(grep "# v[0-9.]\+" $CONF/slackpkg.conf | cut -f2 -dv)
 	fi
 	CHECKSUMSFILE=${WORKDIR}/CHECKSUMS.md5
 	KERNELMD5=$(md5sum /boot/vmlinuz 2>/dev/null)

--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -160,9 +160,9 @@ function system_setup() {
 	# ${CONF}/blacklist.
 	[ "$CMD" != update ] && mkregex_blacklist
 
-    if [ -z "${SLACKCFVERSION}" ]; then
+	if [ -z "${SLACKCFVERSION}" ]; then
 	SLACKCFVERSION=$(grep "# v[0-9.]\+" $CONF/slackpkg.conf | cut -f2 -dv)
-    fi
+	fi
 	CHECKSUMSFILE=${WORKDIR}/CHECKSUMS.md5
 	KERNELMD5=$(md5sum /boot/vmlinuz 2>/dev/null)
 	DIALOG_MAXARGS=${DIALOG_MAXARGS:-19500}

--- a/files/slackpkg.conf.new
+++ b/files/slackpkg.conf.new
@@ -65,7 +65,7 @@
 #SLACKKEY="Slackware Linux Project <security@slackware.com>"
 
 # SLACKCFVERSION defines the Slackware version. If left commented, it
-# will be parsed from the 4th line of thise unedited config file.
+# will be parsed from the 4th line of this unedited config file.
 #SLACKCFVERSION=15.0
 
 # Downloaded files will be in the TEMP directory:

--- a/files/slackpkg.conf.new
+++ b/files/slackpkg.conf.new
@@ -64,6 +64,10 @@
 # as needed
 #SLACKKEY="Slackware Linux Project <security@slackware.com>"
 
+# SLACKCFVERSION defines the Slackware version. If left commented, it
+# will be parsed from the 4th line of thise unedited config file.
+#SLACKCFVERSION=15.0
+
 # Downloaded files will be in the TEMP directory:
 TEMP=/var/cache/packages
 


### PR DESCRIPTION
I've added an extra line to `slackpkg.conf` to define `SLACKCFVERSION` explicitly, rather than with a commented line.

Now users are free to remove all comments from `slackpkg.conf` without breaking `slackpkg` as long as `SLACKCFVERSION` is set in `slackpkg.conf`.

Closes #29 