### PR TITLE
Detect if system is running current

### DIFF
--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -64,6 +64,12 @@ function system_setup() {
 	# Create $WORKDIR just in case
 	mkdir -p "${WORKDIR}"
 
+	# Set the "current" flag if system is running Slackware Current
+	if [ -n "$(echo $SLACKWARE_VERSION | sed -ne 's/.*\(+\|current\)$/\1/pi')" ] && \
+	   [ ! -e ${WORKDIR}/current ]; then
+		touch ${WORKDIR}/current
+	fi
+
 	# Select the command to fetch files and packages from network sources
 	if [ "$DOWNLOADER" = "curl" ]; then
 		DOWNLOADER="curl ${CURLFLAGS} -o"
@@ -188,7 +194,7 @@ as example or overwrite it with slackpkg.conf.new.\n\
 	if [ "$ARCH" = "none" ] && [ "$CMD" != "new-config" ]; then
 		echo -e "\
 \nThe ARCH values in slackpkg.conf are now different. You can remove\n\
-ARCH from there, and slackpkg you use your current ARCH or you can look\n\
+ARCH from there, and slackpkg will use your current ARCH or you can look\n\
 at slackpkg.conf.new or slackpkg.conf manual page to see the new valid\n\
 ARCH values\n"
 		cleanup

--- a/files/slackpkg.conf.5
+++ b/files/slackpkg.conf.5
@@ -102,7 +102,11 @@ is /var/lib/slackpkg.
 .B DOWNLOADER
 .br
 Selects the download application slackpkg will use to fetch files.
-Current options are \fBcurl\fR or \fBwget\fR. Default is wget.
+Current options are "curl" or "wget".
+
+The default value of
+.B DOWNLOADER
+is "wget"
 
 .TP 5
 .B CURLFLAGS

--- a/files/slackpkg.conf.new
+++ b/files/slackpkg.conf.new
@@ -70,9 +70,7 @@ TEMP=/var/cache/packages
 # Package lists, file lists, and others will be stored in WORKDIR:
 WORKDIR=/var/lib/slackpkg
 
-# Use curl or wget for Downloading (wget is default)
-#DOWNLOADER=curl
-
+# Use curl or wget for downloading (wget is default)
 DOWNLOADER=wget
 
 # Special options for curl


### PR DESCRIPTION
If the installed system is Slackware Current, creates the `/var/lib/slackpkg/current` file by default, saving the user from being asked about using a `current` mirror in a Slackware stable install.

Also, a few formatting fixes.

Closes #32
