### PR TITLE
Prevent grep from matching comment

### DIFF
--- a/files/post-functions.sh
+++ b/files/post-functions.sh
@@ -326,7 +326,7 @@ for you to deal with later"
 lookkernel() {
 	NEWKERNELMD5=$(md5sum /boot/vmlinuz 2>/dev/null)
 	if [ "$KERNELMD5" != "$NEWKERNELMD5" ]; then
-		if [ -x /sbin/lilo ] && [ -r /etc/lilo.conf ] && grep -q initrd /etc/lilo.conf ; then
+		if [ -x /sbin/lilo ] && [ -r /etc/lilo.conf ] && grep -q '^[[:space:]]*initrd=' /etc/lilo.conf ; then
 			echo -e "\n
 Your kernel image was updated, and your /etc/lilo.conf indicates
 the use of an initrd for at least one of your kernels. Be sure to

--- a/files/slackpkg
+++ b/files/slackpkg
@@ -452,10 +452,9 @@ case "$CMD" in
 			FOUND=$(echo $SHOWLIST | tr -s ' ' "\n" | grep "slackpkg-[0-9]")
 			if [ "$FOUND" != "" ]; then 
 				getpkg $FOUND upgradepkg Upgrading
-				echo -e "slackpkg was upgraded - you will need start the upgrade process again...\n"
+				echo -e "slackpkg was upgraded - you will need to start the upgrade process again...\n"
 				EXIT_CODE=50
 				cleanup
-				exit ${EXIT_CODE}
 			fi
 			for i in pkgtools aaa_glibc-solibs glibc-solibs aaa_libraries aaa_elflibs readline sed; do
 				FOUND=""


### PR DESCRIPTION
The lookkernel function searches for the pattern 'initrd' in /etc/lilo.conf to determine if the user has an initrd and if so displays the appropriate message. However, the grep command used in the 'if' statement at line 329 will always succeed even if the user doesn't have an initrd line in a kernel block in /etc/lilo.conf. This is due to grep matching a comment line which contains 'initrd' on line 9 of /etc/lilo.conf.

The new grep pattern will only match lines containing the string 'initrd=' which are preceded by zero or more white space starting from the beginning of the line, which will prevent matching commented lines. 