### PR TITLE
Upgrade solibs before install-new

### DIFF
--- a/files/core-functions.sh
+++ b/files/core-functions.sh
@@ -823,7 +823,7 @@ function makelist() {
 				# Search filelist.gz for possible matches
 				for i in ${PRIORITY[@]}; do
 					if [ -e ${WORKDIR}/${i}-filelist.gz ]; then
-						PKGS="$(zegrep -w "${INPUTLIST}" ${WORKDIR}/${i}-filelist.gz | \
+						PKGS="$(zgrep -Ew "${INPUTLIST}" ${WORKDIR}/${i}-filelist.gz | \
 							cut -d\  -f 1 | awk -F'/' '{print $NF}')"
 						for FULLNAME in $PKGS ; do
 							NAME=$(cutpkg ${FULLNAME})

--- a/files/slackpkg
+++ b/files/slackpkg
@@ -467,6 +467,12 @@ case "$CMD" in
 		fi
 	;;
 	install-new)
+		CMD=upgrade
+		makelist solibs
+		ULIST=${LIST}
+
+		unset LIST
+		CMD=install-new
 		makelist ${INPUTLIST}
 		if ! [ -n "${LIST}" ]; then	
 			echo -e "No packages match the pattern for install. Try:"
@@ -475,6 +481,11 @@ case "$CMD" in
 			EXIT_CODE=20
 		else
 			showlist "$LIST" install
+			if [ -n "$ULIST" ]; then
+				for i in $ULIST ; do
+					getpkg $i upgradepkg Upgrading
+				done
+			fi
 			install_pkg
 		fi
 	;;


### PR DESCRIPTION
If the new packages are compiled with the newer libraries they can broke the system, as most base solibs (like glibc) have their separated solibs packages, upgrade them first and install the new packages after that.