### PR TITLE
Update files to release 16.0.0

### DIFF
--- a/files/ChangeLog
+++ b/files/ChangeLog
@@ -1,11 +1,33 @@
+Fri Sep 11 20:53:05 UTC 2026
+---------------
+	- Release 16.0.0
+	- Upgrade solibs before install-new (Piter PUNK)
+	- Install mkinitrd early (Patrick Volkerding)
+	- Set ROWS properly when running from cron
+					(allend, Petri Kaukasoina, Lockywolf)
+	- Detect gpg version and prefer using gpg1 if available
+							   (Petri Kaukasoina)
+	- Allows automatic cleanup of upgraded packages metadata (Piter PUNK)
+	- Ignore case in search (Shamil Bikineyev)
+	- Not apply blacklist for search and download (Shamil Bikineyev)
+	- Prevent initrd detection grep to match comments in /etc/lilo.conf
+							    (Brandon Pribula)
+	- Update slackpkg.conf.new and slackpkg.conf.5
+						 (Peter Hyman and Piter PUNK)
+	- Detects if installed system is Slackware Current (Piter PUNK)
+	- Fix formatting, alignments and typos
+	                      (Tristan Terpelle, Piter PUNK, Brandon Pribula)
+	- Fix warning about stray \ before / (Shamil Bikineyev)
+	- Remove usage of egrep and fgrep (Shamil Bikineyev)
+
 Mon Jan 17 06:40:41 UTC 2022
 ---------------
 	- Release 15.0.10
 	- Fix mirrors.ucr.ac.cr link address (Emmet Ford)
 	- Remove wroc.pl mirrors (Emmet Ford)
 	- Remove kddilabs.jp from mirrors (Emmet Ford)
-	- Unattended usage improvements (PiterPUNK)
-	- Create file to flag if the system needs restart (PiterPUNK)
+	- Unattended usage improvements (Piter PUNK)
+	- Create file to flag if the system needs restart (Piter PUNK)
 
 Mon Dec 13 00:27:34 UTC 2021
 ---------------

--- a/files/README
+++ b/files/README
@@ -8,57 +8,7 @@
 					<rworkman@slackware.com>
 					(since 2.82.2)
 
-			Version: 0.93   released at Fri Feb 14 2003
-				 0.94   released at Wed Mar 12 2003
-				 0.95   released at Mon Mar 17 2003
-				 0.96   released at Thu Apr 10 2003
-				 0.97   released at Fri Aug 01 2003
-				 0.98   released at Tue Aug 19 2003
-				 0.99   released at Mon Sep 15 2003
-				 0.99.1 released at Wed Sep 24 2003
-				 1.00	released at Mon Nov 10 2003
-				 1.02	released at Fri Jan 30 2004
-				 1.02.1	released at Mon Feb 02 2004
-				 1.02.2	released at Mon Feb 02 2004
-				 1.03	released at Wed Feb 18 2004
-				 1.03.1	released at Thu Feb 26 2004 
-				 1.1	released at Mon Mar 01 2004
-				 1.2	released at Tue Mar 30 2004
-				 1.2.1  released at Wed May 19 2004
-				 1.2.2  released at Tue Jun 15 2004 
-				 1.3	released at Mon Nov 01 2004
-				 1.3.1	released at Wed Dec 29 2004
-				 1.4	released at Wed Jan 26 2005
-				 1.4.1	released at Tue Jun 22 2005
-				 1.5.0	released at Fri Jul 22 2005
-				 1.5.1	released at Wed Aug 17 2005
-				 1.5.2	released at Sun Sep 11 2005
-				 2.03   released at Thu May 18 2006
-				 2.04   released at Fri May 26 2006
-				 2.05	released at Thu Jun 08 2006
-				 2.06	released at Fri Jul 28 2006
-				 2.07	released at Sun Aug 13 2006
-				 2.08	released at Fri Aug 18 2006
-				 2.09	released at Mon Aug 28 2006
-				 2.52	released at Sat Mar 17 2007
-				 2.60	released at Tue May 08 2007
-				 2.61	released at Sat Jun 09 2007
-				 2.70   released at Tue Jan 29 2008 
-				 2.70.1 released at Sat Mar 15 2008 
-				 2.70.2 released at Tue Apr 08 2008 
-				 2.70.3 released at Wed Apr 30 2008 
-				 2.70.4 released at Fri May 01 2008 
-				 2.70.5 released at Thu Dec 04 2008 
-				 2.71	released at Thu Apr 23 2009 
-				 2.71.1 released at Sat May 02 2009
-				 2.80	released at Thu Jun 18 2009
-				 2.80.1 released at Tue Jul 14 2009
-				 2.80.2 released at Thu Jul 30 2009
-				 2.81   released at Fri Apr 23 2010
-				 2.81.1 released at Thu May 13 2010
-				 2.82.0 released at Thu Mar 24 2011
-				 2.82.1 released at Wed May 11 2016
-				 2.82.2 released at Sun Oct 08 2017
+			Stable version: 16.0.0
 
   Slackpkg is a tool for those who want to easily install or upgrade packages 
   via the network.  With slackpkg, you can have a minimal installation of 

--- a/files/slackpkg.conf.5
+++ b/files/slackpkg.conf.5
@@ -1,4 +1,4 @@
-.TH SLACKPKG.CONF 5 "June 2022" slackpkg-15.0.10 ""
+.TH SLACKPKG.CONF 5 "September 2026" slackpkg-16.0.0 ""
 .SH NAME
 .B slackpkg.conf
 \- Configuration data for slackpkg

--- a/files/slackpkg.conf.new
+++ b/files/slackpkg.conf.new
@@ -1,7 +1,7 @@
 #
 # /etc/slackpkg/slackpkg.conf
 # Configuration for SlackPkg
-# v15.0
+# v16.0
 #
 
 # SlackPkg - An Automated packaging tool for Slackware Linux
@@ -66,7 +66,7 @@
 
 # SLACKCFVERSION defines the Slackware version. If left commented, it
 # will be parsed from the 4th line of this unedited config file.
-#SLACKCFVERSION=15.0
+#SLACKCFVERSION=16.0
 
 # Downloaded files will be in the TEMP directory:
 TEMP=/var/cache/packages

--- a/slackpkg.SlackBuild
+++ b/slackpkg.SlackBuild
@@ -23,7 +23,7 @@
 cd $(dirname $0) ; CWD=$(pwd)
 
 PKGNAM=slackpkg
-VERSION=${VERSION:-15.0.10}
+VERSION=${VERSION:-16.0.0}
 ARCH="noarch"
 BUILD=${BUILD:-1}
 


### PR DESCRIPTION
Fri Sep 11 20:53:05 UTC 2026
---------------
        - Release 16.0.0
        - Upgrade solibs before install-new (Piter PUNK)
        - Install mkinitrd early (Patrick Volkerding)
        - Set ROWS properly when running from cron
                                        (allend, Petri Kaukasoina, Lockywolf)
        - Detect gpg version and prefer using gpg1 if available
                                                           (Petri Kaukasoina)
        - Allows automatic cleanup of upgraded packages metadata (Piter PUNK)
        - Ignore case in search (Shamil Bikineyev)
        - Not apply blacklist for search and download (Shamil Bikineyev)
        - Prevent initrd detection grep to match comments in /etc/lilo.conf
                                                            (Brandon Pribula)
        - Update slackpkg.conf.new and slackpkg.conf.5
                                                 (Peter Hyman and Piter PUNK)
        - Detects if installed system is Slackware Current (Piter PUNK)
        - Fix formatting, alignments and typos
                              (Tristan Terpelle, Piter PUNK, Brandon Pribula)
        - Fix warning about stray \ before / (Shamil Bikineyev)
        - Remove usage of egrep and fgrep (Shamil Bikineyev)
